### PR TITLE
feat: 템플릿 복제, fix: 로그 관련

### DIFF
--- a/src/main/java/com/tag/prietag/controller/KpiLogController.java
+++ b/src/main/java/com/tag/prietag/controller/KpiLogController.java
@@ -25,7 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "DashBoard", description = "대시보드 API Document")
 public class KpiLogController {
-    KpiLogService kpiLogService;
+    private final KpiLogService kpiLogService;
     @PostMapping("/log/kpi")
     @Operation(summary = "고객 방문 로그 저장", description = "고객이 방문 또는 결재 했을때의 로그를 저장합니다")
     public ResponseEntity<?> saveCustomerKpi(@RequestBody @Valid LogRequest.CustomerLogInDTO customerLogInDTO, Error errors){

--- a/src/main/java/com/tag/prietag/controller/TemplateController.java
+++ b/src/main/java/com/tag/prietag/controller/TemplateController.java
@@ -110,9 +110,9 @@ public class TemplateController {
         } else if (templateId != null && versionId != null) {
             throw new IllegalArgumentException("templateId 또는 versionId 둘 중 하나만 입력해주세요.");
         } else if (templateId != null) {
-            result = templateService.publishTemplate(templateId, myUserDetails.getUser());
+            result = templateService.publishTemplate(templateId, myUserDetails.getUser().getId());
         } else {
-            result = templateService.publishTemplateVS(versionId, myUserDetails.getUser());
+            result = templateService.publishTemplateVS(versionId, myUserDetails.getUser().getId());
         }
         return ResponseEntity.ok(new ResponseDTO<>(result));
     }

--- a/src/main/java/com/tag/prietag/core/config/MySecurityConfig.java
+++ b/src/main/java/com/tag/prietag/core/config/MySecurityConfig.java
@@ -95,7 +95,8 @@ public class MySecurityConfig {
         // 11. 인증, 권한 필터 설정
         http.authorizeRequests(
                 authorize -> authorize.antMatchers("/healthCheck", "/api/callback", "/template/user/**", "/oauth2/authorization/kakao",
-                                "/api/test/join", "/api/test/login", "/h2-console/**", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
+                                "/api/test/join", "/api/test/login", "/h2-console/**", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**",
+                                "/api/log/kpi").permitAll()
                         .antMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest()
                         .authenticated()

--- a/src/main/java/com/tag/prietag/model/Template.java
+++ b/src/main/java/com/tag/prietag/model/Template.java
@@ -19,7 +19,7 @@ public class Template extends TimeStamped {
     @ManyToOne(fetch = FetchType.LAZY)
     User user;
 
-    @Column(nullable = false, length = 20, unique = true)
+    @Column(nullable = false, length = 50, unique = true)
     String mainTitle;
 
     @Column(nullable = false)

--- a/src/main/java/com/tag/prietag/service/KpiLogService.java
+++ b/src/main/java/com/tag/prietag/service/KpiLogService.java
@@ -28,9 +28,9 @@ import java.util.*;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class KpiLogService {
-    TemplateVersionRepository templateVersionRepository;
-    CustomerLogRepository customerLogRepository;
-    PublishLogRepository publishLogRepository;
+    private final TemplateVersionRepository templateVersionRepository;
+    private final CustomerLogRepository customerLogRepository;
+    private final PublishLogRepository publishLogRepository;
 
     @Transactional
     public void saveCustomerKpi(LogRequest.CustomerLogInDTO customerLogInDTO) {

--- a/src/main/java/com/tag/prietag/service/TemplateService.java
+++ b/src/main/java/com/tag/prietag/service/TemplateService.java
@@ -255,21 +255,26 @@ public class TemplateService {
         // 가장 높은 버전 템플릿 가져오기
         TemplateVersion originTemplateVersion = templateVersionRepository.findMaxVersionTemplate(templateId);
 
-        StringBuilder mainTitle = new StringBuilder(originTemplate.getMainTitle());
+        String mainTitle = originTemplate.getMainTitle();
         // 템플릿 이름을 포함한 템플릿 가져오기
-        List<Template> templateList = templateRepository.findByMainTitleContainingAndIsDeleted(mainTitle.toString(), false);
-        int index = 1;
-        while (templateList.size() != 0) {
-            mainTitle.append("_").append(index);
-            if (templateList.stream().anyMatch(template -> template.getMainTitle().equals(mainTitle.toString()))) {
-                index++;
-            } else {
-                break;
+        List<Template> templateList = templateRepository.findByMainTitleContainingAndIsDeleted(mainTitle, false);
+        if (templateList.size() == 1) {
+            mainTitle = mainTitle + " (복제됨)";
+        } else {
+            int index = 2;
+            while (true) {
+                String finalMainTitle = mainTitle + " (복제됨_" + index + ")";
+                if (templateList.stream().anyMatch(template -> template.getMainTitle().equals(finalMainTitle))) {
+                    index++;
+                } else {
+                    break;
+                }
             }
+            mainTitle = mainTitle + " (복제됨_" + index + ")";
         }
 
         // 새로운 Template 엔티티 생성 및 저장
-        Template newTemplate = new Template(user, mainTitle.toString());
+        Template newTemplate = new Template(user, mainTitle);
         templateRepository.save(newTemplate);
 
         // 새로운 TemplateVersion 엔티티 생성 및 저장

--- a/src/main/java/com/tag/prietag/service/TemplateService.java
+++ b/src/main/java/com/tag/prietag/service/TemplateService.java
@@ -363,10 +363,13 @@ public class TemplateService {
 
     // 템플릿 퍼블리싱 (최신)
     @Transactional
-    public String publishTemplate(Long templateId, User user) {
+    public String publishTemplate(Long templateId, Long userId) {
         // 버전이 가장 높은 templateVersion의 id
         Long maxVersionId = templateVersionRepository.findIdByTemplateIdMaxVersion(templateId);
 
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new IllegalArgumentException("해당 유저가 없습니다.")
+        );
         // 퍼블리싱된 templateVersion의 id 수정
         user.setPublishId(maxVersionId);
 
@@ -376,7 +379,11 @@ public class TemplateService {
 
     // 템플릿 퍼블리싱 (버전 선택)
     @Transactional
-    public String publishTemplateVS(Long versionId, User user) {
+    public String publishTemplateVS(Long versionId, Long userId) {
+
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new IllegalArgumentException("해당 유저가 없습니다.")
+        );
         // 퍼블리싱된 templateVersion의 id 수정
         user.setPublishId(versionId);
 

--- a/src/main/java/com/tag/prietag/service/TemplateService.java
+++ b/src/main/java/com/tag/prietag/service/TemplateService.java
@@ -5,7 +5,9 @@ import com.tag.prietag.core.util.S3Uploader;
 import com.tag.prietag.dto.template.TemplateRequest;
 import com.tag.prietag.dto.template.TemplateResponse;
 import com.tag.prietag.model.*;
+import com.tag.prietag.model.log.PublishLog;
 import com.tag.prietag.repository.*;
+import com.tag.prietag.repository.log.PublishLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -31,6 +33,7 @@ public class TemplateService {
     private final FaqRepository faqRepository;
     private final TemplateRepository templateRepository;
     private final TemplateVersionRepository templateVersionRepository;
+    private final PublishLogRepository publishLogRepository;
     private final UserRepository userRepository;
     private final S3Uploader s3Uploader;
 
@@ -370,8 +373,20 @@ public class TemplateService {
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new IllegalArgumentException("해당 유저가 없습니다.")
         );
+
+        TemplateVersion templateVersion = templateVersionRepository.findById(maxVersionId).orElseThrow(
+                () -> new IllegalArgumentException("해당 템플릿 버전이 없습니다.")
+        );
+
         // 퍼블리싱된 templateVersion의 id 수정
         user.setPublishId(maxVersionId);
+
+        // 퍼블리시 로그 테이블에 저장
+        PublishLog publishLog = PublishLog.builder()
+                .user(user)
+                .templatevs(templateVersion)
+                .build();
+        publishLogRepository.save(publishLog);
 
         return "퍼블리싱된 버전 id = " + maxVersionId;
     }
@@ -384,8 +399,20 @@ public class TemplateService {
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new IllegalArgumentException("해당 유저가 없습니다.")
         );
+
+        TemplateVersion templateVersion = templateVersionRepository.findById(versionId).orElseThrow(
+                () -> new IllegalArgumentException("해당 템플릿 버전이 없습니다.")
+        );
+
         // 퍼블리싱된 templateVersion의 id 수정
         user.setPublishId(versionId);
+
+        // 퍼블리시 로그 테이블에 저장
+        PublishLog publishLog = PublishLog.builder()
+                .user(user)
+                .templatevs(templateVersion)
+                .build();
+        publishLogRepository.save(publishLog);
 
         return "퍼블리싱된 버전 id = " + versionId;
     }


### PR DESCRIPTION
## Motivation

- 템픞릿 복제 요구사항 반영 (복제됨 넘버링)
- 퍼블리시 로그 추가
- 템플릿 타이틀 길이 제한 수정
- 퍼블리시 유저 정보 수정
- KPI 로그 컨트롤러/서비스 의존성
- KPI 로그 저장 경로 인증 허용


## Proposed Changes

- 템플릿 복제 &rarr; 템플릿 (복제됨)
- 템플릿 다시 복제 &rarr;  (복제됨_2)
- 템플릿 (복제됨) 복제 &rarr; 템플릿 (복제됨) (복제됨) 
